### PR TITLE
update use of time & example-robot-data

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -2,6 +2,7 @@ import numpy as np
 from IPython import embed
 from matplotlib import pyplot as plt
 from solo_estimator import BaseEstimator
+from example_robot_data.robots_loader import load_full
 data = np.load("/tmp/data_main_solo12_estimation.npz")
 # data = np.load("data_main_solo12_estimation_with_control.npz")
 # data = np.load("data_main_solo12_estimation.npz")
@@ -35,7 +36,8 @@ for i in range(1,N):
 
 velocityKinematic =  np.zeros([4,N,3])
 
-be = BaseEstimator(urdf="/opt/openrobots/lib/python3.5/site-packages/../../../share/example-robot-data/robots/solo_description/robots/solo12.urdf",modelPath="/opt/openrobots/lib/python3.5/site-packages/../../../share/example-robot-data/robots",contactFrameNames = ['HR_FOOT', 'HL_FOOT', 'FR_FOOT', 'FL_FOOT'])
+robot, q0, urdf, srdf = load_full('solo12')
+be = BaseEstimator(urdf=urdf,modelPath='/'.join(urdf.split('/')[:-3]),contactFrameNames = ['HR_FOOT', 'HL_FOOT', 'FR_FOOT', 'FL_FOOT'])
 
 #example of use:
 for i in range(N):

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,7 +1,7 @@
 '''This class will log 1d array in Nd matrix from device and qualisys object'''
 import numpy as np
 from datetime import datetime as datetime
-from time import clock
+from time import time
 
 class Logger():
     def __init__(self, device, qualisys=None, logSize=60e3, ringBuffer=False):
@@ -93,7 +93,7 @@ class Logger():
             self.v_filt[self.i] = estimator.v_filt[:, 0]
 
         # Logging timestamp
-        self.tstamps[self.i] = clock()
+        self.tstamps[self.i] = time()
 
         self.i += 1
 

--- a/utils/viewerClient.py
+++ b/utils/viewerClient.py
@@ -4,6 +4,9 @@ from ctypes import c_double
 import pinocchio as pin
 import numpy as np
 import time
+from example_robot_data.robots_loader import load
+
+
 class NonBlockingViewerFromRobot():
     def __init__(self,robot,dt=0.01):
         # a shared c_double array
@@ -11,7 +14,7 @@ class NonBlockingViewerFromRobot():
         self.shared_q_viewer = Array(c_double, robot.nq, lock=False)
         self.p = Process(target=self.display_process, args=(robot, self.shared_q_viewer))
         self.p.start()
-        
+
     def display_process(self,robot, shared_q_viewer):
         ''' This will run on a different process'''
         q_viewer = robot.q0.copy()
@@ -24,7 +27,7 @@ class NonBlockingViewerFromRobot():
     def display(self,q):
         for i in range(len(self.shared_q_viewer)):
             self.shared_q_viewer[i] = q[i]
-    
+
 
     def stop(self):
         self.p.terminate()
@@ -32,12 +35,10 @@ class NonBlockingViewerFromRobot():
 
 
 class viewerClient():
-    def __init__(self,urdf="/opt/openrobots/share/example-robot-data/robots/solo_description/robots/solo12.urdf",modelPath="/opt/openrobots/share/example-robot-data/robots",dt=0.01):
-        pin.switchToNumpyMatrix()
-        robot = pin.RobotWrapper.BuildFromURDF( urdf, modelPath, pin.JointModelFreeFlyer())
-        robot.initViewer(loadModel=True)
+    def __init__(self,dt=0.01):
+        robot = load('solo12', display=True)
         if ('viewer' in robot.viz.__dict__):
-            robot.viewer.gui.setRefreshIsSynchronous(False)        
+            robot.viewer.gui.setRefreshIsSynchronous(False)
         self.nbv = NonBlockingViewerFromRobot(robot,dt)
 
     def display(self,q):


### PR DESCRIPTION
Hello,

Here are a few details to make things work on my setup:
- `time.clock()` is not available in recent python version
- use example-robot-data loaders to get full paths to urdf instead of hardcoding those

Can you confirm that this is not breaking anything for you ? (you need example-robot-data >= v3.7.0)